### PR TITLE
Fix silent failure with unsaved file

### DIFF
--- a/PrintToHTML.py
+++ b/PrintToHTML.py
@@ -207,8 +207,12 @@ def get_lexer(filename, syntax, text):
             pass
 
     # guess lexer by analyzing the text
-    lexer = pygments.lexers.guess_lexer(text)
-    print('Guessed lexer from text analysis:', lexer)
+    try:
+        lexer = pygments.lexers.guess_lexer(text)
+        print('Guessed lexer from text analysis:', lexer)
+    except pygments.util.ClassNotFound:
+        lexer = pygments.lexers.TextLexer()
+        print('Failed to guess syntax, fell back to plaintext')
     return lexer
 
 


### PR DESCRIPTION
To reproduce the bug this fixes (as of Linux ST3 build 3114 anyway):
1. Create new window with some text. Don't save.
2. Set the syntax to something other than plain text.
3. Run "Print as HTML via browser" command

Currently the command silently fails (a `pygments.util.ClassNotFound`  exception is logged in the console). This catches the exception and falls back to plain text.

(There may be an alternative fix that accurately picks up the syntax setting from ST, I didn't have time to pursue that.)
